### PR TITLE
Automatically add `triage/awaiting` to new issues

### DIFF
--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -1,0 +1,17 @@
+name: Label issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Label issues
+        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
+        with:
+          add-labels: "triage/awaiting"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -11,7 +11,7 @@ jobs:
       issues: write
     steps:
       - name: Label issues
-        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
+        uses: andymckay/labeler@master
         with:
           add-labels: "triage/awaiting"
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
GitHub Action workflow to automatically add `triage/awaiting` label on creation of new issues.

Fixes: #8 