### PR TITLE
Fixed Subscribe newsletter component

### DIFF
--- a/src/components/newsletter/Newsletter.js
+++ b/src/components/newsletter/Newsletter.js
@@ -27,7 +27,7 @@ const Newsletter = () => {
           <div className={styles.newsletter_a}>
             <p className={styles.newsletter_a_p}>Join the mailing list:</p>
             <form
-              action="https://www.getrevue.co/profile/saiyampathak/add_subscriber"
+              action="https://blog.kubesimplify.com/newsletter"
               method="post"
               id="revue-form"
               name="revue-form"


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
#232 

## Changes proposed
Simply replaced that old getrevue website link with kubesimplify's newsletter page of hashnode with this link
`https://blog.kubesimplify.com/newsletter`.

## Screenshots
![image](https://github.com/kubesimplify/website/assets/72792907/64955d0a-c9c9-471b-bdf5-4bf7a8f7f463)

<!-- Add all the screenshots which support your changes -->

