### PR TITLE
blog: A Backup Is Not Disaster Recovery - three Kubernetes DR demos

### DIFF
--- a/content/blog/a-backup-is-not-disaster-recovery.md
+++ b/content/blog/a-backup-is-not-disaster-recovery.md
@@ -4,11 +4,11 @@ seoTitle: "A Backup Is Not Disaster Recovery: Three Kubernetes DR Demos"
 seoDescription: "Three live Kubernetes demos - Velero restores, the GitOps trap, and VolumeGroupSnapshot - that show why backups alone are not disaster recovery."
 datePublished: 2026-08-14T10:00:00.000Z
 slug: a-backup-is-not-disaster-recovery
-author: saiyam-pathak
+authors: ["saiyam-pathak", "saloni-narang"]
 cover: /img/blog/a-backup-is-not-disaster-recovery/lab-setup.svg
 tags: ["kubernetes", "disaster-recovery", "velero", "gitops"]
 ---
-At KubeCon + CloudNativeCon Japan 2026, Saloni and I gave a talk called "Is
+At KubeCon + CloudNativeCon Japan 2026, the two of us gave a talk called "Is
 Your Kubernetes Disaster Recovery Actually Ready?" We opened with a poll.
 Raise your hand if you take backups of your clusters. Almost every hand in the
 room went up. Keep it up if you have ever restored a complete stateful
@@ -54,8 +54,8 @@ layers usually recover fine. Recovery fails at the joins between them.
 
 Let's walk through the lab. Two clusters and two services, all local:
 
-- **Production** runs on [kiac](https://github.com/saiyam1814/kiac), my open
-  source project that runs Kubernetes in Apple containers. Every node is its
+- **Production** runs on [kiac](https://github.com/saiyam1814/kiac), Saiyam's
+  open source project that runs Kubernetes in Apple containers. Every node is its
   own lightweight VM with its own kernel. This matters in demo 2: losing
   production means powering off a machine, not stopping a container that
   pretends to be one.
@@ -121,7 +121,7 @@ actual Postgres volume data left the cluster and landed in the S3 vault - the
 data itself, not just the YAML. If your backup tool cannot show you this
 number, ask it why.
 
-On stage I then deleted the whole namespace, PVC included, and restored it
+On stage we then deleted the whole namespace, PVC included, and restored it
 with one command:
 
 ```bash
@@ -160,7 +160,7 @@ gets restored into.
 
 ![The GitOps trap: Argo rebuilds the declarations, the vault holds the data](/img/blog/a-backup-is-not-disaster-recovery/gitops-trap.svg)
 
-This is the demo the room remembers. I recorded the time and powered off the
+This is the demo the room remembers. We recorded the time and powered off the
 production VM:
 
 ```console
@@ -195,7 +195,7 @@ velero               Active   12d
 No guestbook. This cluster has never run our app.
 
 Now the 2026 on-call reflex: we have GitOps, the whole app is declared in
-Git, just sync it. So I triggered Argo CD and waited for it to go green:
+Git, just sync it. So we triggered Argo CD and waited for it to go green:
 
 ```bash
 kubectl -n argocd patch application guestbook --type merge \
@@ -214,8 +214,8 @@ NAME        SYNC STATUS   HEALTH STATUS
 guestbook   Synced        Progressing
 ```
 
-Synced. Postgres Running and Ready. Every dashboard green. On stage I said
-this is the moment half the room posts "we are recovered" in Slack. Then I
+Synced. Postgres Running and Ready. Every dashboard green. On stage we said
+this is the moment half the room posts "we are recovered" in Slack. Then we
 queried the data:
 
 ```console
@@ -267,8 +267,8 @@ something you test, not assume.
 
 Now the stopwatch. On stage, from powering off production to validated data
 in the recovery cluster took four minutes, 16:06 to 16:10 on the on-screen
-clock. The capture above, a rehearsed rerun, took just under two. The line I
-used on stage is the one I want you to keep: the first time we "recovered,"
+clock. The capture above, a rehearsed rerun, took just under two. The line we
+used on stage is the one we want you to keep: the first time we "recovered,"
 when the dashboards went green and the Slack message went out, was not the
 recovery. The second time, when the data came back and we checked it, was.
 And remember this measures only the scripted slice. A production RTO wraps
@@ -283,7 +283,7 @@ Kafka brokers, replica sets. Our stand-in is a tiny ledger app writing
 matched pairs, order n to one PVC and payment n to another, five times a
 second. One invariant: every payment must have its order.
 
-I snapshotted the orders volume, let the app keep writing for five seconds,
+We snapshotted the orders volume, let the app keep writing for five seconds,
 then snapshotted the payments volume. Each one is a plain CSI VolumeSnapshot,
 and 121152 is the run id the lab script stamps on every object in one run:
 
@@ -309,7 +309,7 @@ volumesnapshot.snapshot.storage.k8s.io/torn-payments-121152 created
 volumesnapshot.snapshot.storage.k8s.io/torn-payments-121152 condition met
 ```
 
-Both ReadyToUse. Both individually perfect. Then I restored both into new
+Both ReadyToUse. Both individually perfect. Then we restored both into new
 PVCs using dataSource, the standard way to restore any CSI snapshot, and ran
 a verifier job that mounts both restored volumes and compares the last
 sequence number on each:
@@ -398,7 +398,7 @@ last payment committed : 109169
 [OK] Every payment has a matching order. Restore is consistent.
 ```
 
-Full disclosure, the same one I gave on stage: my lab uses the CSI hostpath
+Full disclosure, the same one we gave on stage: our lab uses the CSI hostpath
 test driver, which implements the group RPCs but archives member volumes
 sequentially, so the writer is paused during the group snapshot to keep the
 demo deterministic. What the demo shows is the GA API and the restore
@@ -408,7 +408,7 @@ backend of a production driver. Which leads to the practical takeaways:
 - Support is driver specific. A driver that supports ordinary
   VolumeSnapshots proves nothing about group snapshots. Ask your storage
   vendor whether they implement the CSI group RPCs. As of mid 2026, most of
-  the major cloud drivers I checked do not.
+  the major cloud drivers we checked do not.
 - Setup is explicit: the CRDs and feature gates on the snapshot controller
   and CSI sidecar are your job.
 - Crash consistent is not application consistent. The API removes cross
@@ -433,8 +433,8 @@ The demos expose gaps that no single tool closes today:
    target, validates data and the user path, and measures the whole thing.
 
 There is community work here: the Cloud Native Business Continuity initiative
-proposal under CNCF TAG Operational Resilience (disclosure: I am one of the
-TAG chairs). It is an open proposal seeking contributors, aiming at a
+proposal under CNCF TAG Operational Resilience (disclosure: Saiyam is one of
+the TAG chairs). It is an open proposal seeking contributors, aiming at a
 landscape gap analysis, updated backup and DR guidance, and reference
 architectures. If this post resonates, that is where to help:
 https://github.com/cncf/toc/issues/1779
@@ -454,7 +454,7 @@ modes and timings still need testing on your production platforms.
 
 ## Now the questions are for you
 
-We ended the talk with questions instead of answers, and I will end this post
+We ended the talk with questions instead of answers, and we will end this post
 the same way. Answer these honestly, ideally out loud in your next team
 meeting:
 
@@ -485,7 +485,7 @@ panic or ending in a runbook she has already executed.
 The lab, the commands, and everything you saw here:
 https://github.com/saiyam1814/kubecon-japan-dr-demo
 
-I would genuinely like to hear what you do today: who owns DR at your
-company, and when did you last run a real restore? Tell me on
+We would genuinely like to hear what you do today: who owns DR at your
+company, and when did you last run a real restore? Tell us on
 [X](https://x.com/saiyampathak) or
 [LinkedIn](https://linkedin.com/in/saiyampathak).

--- a/content/blog/a-backup-is-not-disaster-recovery.md
+++ b/content/blog/a-backup-is-not-disaster-recovery.md
@@ -1,0 +1,491 @@
+---
+title: "A Backup Is Not Disaster Recovery: Three Kubernetes Demos That Prove It"
+seoTitle: "A Backup Is Not Disaster Recovery: Three Kubernetes DR Demos"
+seoDescription: "Three live Kubernetes demos - Velero restores, the GitOps trap, and VolumeGroupSnapshot - that show why backups alone are not disaster recovery."
+datePublished: 2026-08-14T10:00:00.000Z
+slug: a-backup-is-not-disaster-recovery
+author: saiyam-pathak
+cover: /img/blog/a-backup-is-not-disaster-recovery/lab-setup.svg
+tags: ["kubernetes", "disaster-recovery", "velero", "gitops"]
+---
+At KubeCon + CloudNativeCon Japan 2026, Saloni and I gave a talk called "Is
+Your Kubernetes Disaster Recovery Actually Ready?" We opened with a poll.
+Raise your hand if you take backups of your clusters. Almost every hand in the
+room went up. Keep it up if you have ever restored a complete stateful
+application into a clean cluster. We looked around the room. Nobody.
+
+That gap between the two questions is this entire post. Everything below ran
+live on stage on one laptop with the Wi-Fi off, and every terminal output you
+see here is a real capture from a rerun of the same lab, not a mockup. The
+full lab is reproducible from this repo:
+https://github.com/saiyam1814/kubecon-japan-dr-demo
+
+## The one sentence version
+
+A backup is a recovery point you have. Disaster recovery is a capability you
+can prove. The three demos walk from the comfortable half of that sentence to
+the uncomfortable half.
+
+## Two numbers rule everything
+
+![RPO and RTO on one timeline](/img/blog/a-backup-is-not-disaster-recovery/rpo-rto.svg)
+
+- **RPO (recovery point objective)** is how much data the business can afford
+  to lose. Hourly backups can support roughly an hour of RPO, but only if
+  every backup completes and the recovery point is usable. Your achieved RPO
+  is the latest recoverable point, not the schedule.
+- **RTO (recovery time objective)** is how long until you serve users again,
+  including detection, decision making, infrastructure recovery, data restore,
+  validation, and traffic cutover.
+
+We kept returning to one point on stage: almost nobody has a real RTO
+number. People have estimates. An estimate is a guess until a stopwatch has
+watched a restore. By the end of this post you will see our stopwatch number.
+
+And what has to come back for recovery to count? Four layers: cluster state,
+application definitions, persistent data, and access plus traffic. Individual
+layers usually recover fine. Recovery fails at the joins between them.
+
+![The four recovery layers](/img/blog/a-backup-is-not-disaster-recovery/layers.svg)
+
+## The lab
+
+![The whole lab in one picture](/img/blog/a-backup-is-not-disaster-recovery/lab-setup.svg)
+
+Let's walk through the lab. Two clusters and two services, all local:
+
+- **Production** runs on [kiac](https://github.com/saiyam1814/kiac), my open
+  source project that runs Kubernetes in Apple containers. Every node is its
+  own lightweight VM with its own kernel. This matters in demo 2: losing
+  production means powering off a machine, not stopping a container that
+  pretends to be one.
+- **Recovery** is a kind cluster that exists before anything goes wrong,
+  which is the first rule of DR.
+- **The backup vault** is SeaweedFS, an S3-compatible object store. Both
+  clusters point their Velero at the same bucket. The vault lives outside
+  both clusters on purpose, so losing either cluster can never take the
+  recovery points with it. To be clear, "vault" here means the backup store,
+  not a secret store.
+- **Git** is a local Gitea with the app manifests, watched by Argo CD in the
+  recovery cluster.
+
+The app is a Postgres guestbook with four rows. Row four is Fatima, our
+fictional on-call engineer. Her note says "owns the pager tonight." Her pager
+goes off at 2:07 AM when the region hosting her cluster disappears, and the
+monitoring dashboard times out because monitoring lived in the same cluster.
+Keep her in mind.
+
+## Demo 1: the backup is real, and what Velero actually does
+
+![Velero moves objects and volume bytes to an S3 store](/img/blog/a-backup-is-not-disaster-recovery/velero-flow.svg)
+
+[Velero](https://www.cncf.io/projects/velero/) entered the CNCF Sandbox in
+March 2026. It backs up Kubernetes
+resources and persistent volume data, and it can protect that volume data
+three ways: provider or CSI snapshots, file system backup, or CSI Snapshot
+Data Movement. Our lab uses the last one.
+
+Here is production before anything happens:
+
+```console
+$ kubectl -n guestbook exec statefulset/postgres -- \
+    psql -U postgres -d guestbook -c 'select * from attendees;'
+ id |  name  |            note
+----+--------+-----------------------------
+  1 | Priya  | came for the demos
+  2 | Marcus | still calls it swarm
+  3 | Chen   | has tested a restore. once.
+  4 | Fatima | owns the pager tonight
+(4 rows)
+```
+
+One Velero backup of the namespace already ran. Find it and keep its name:
+
+```bash
+kubectl -n velero get backups.velero.io
+export BACKUP=guestbook-rehearsal-20260727001126   # your newest Completed one
+```
+
+Most people stop checking at the green status. Go one step further and look
+at the part almost nobody checks, the DataUpload:
+
+```console
+$ kubectl -n velero get datauploads -l velero.io/backup-name=$BACKUP \
+    -o custom-columns='NAME:.metadata.name,PHASE:.status.phase,BYTES:.status.progress.bytesDone'
+NAME                                       PHASE       BYTES
+guestbook-rehearsal-20260727001126-q2j9m   Completed   47989888
+```
+
+That is Velero's data mover (Kopia) confirming that 47,989,888 bytes of
+actual Postgres volume data left the cluster and landed in the S3 vault - the
+data itself, not just the YAML. If your backup tool cannot show you this
+number, ask it why.
+
+On stage I then deleted the whole namespace, PVC included, and restored it
+with one command:
+
+```bash
+kubectl delete namespace guestbook --wait
+velero restore create --from-backup "$BACKUP" --wait
+```
+
+The same four rows came back. Useful, real, and about two minutes. But this
+is the happy path, and it hides three things Velero does not do
+automatically:
+
+1. Protecting volume data does not automatically make a database backup
+   application consistent. You configure
+   [backup hooks](https://velero.io/docs/v1.18/backup-hooks/) to flush or
+   quiesce when the app requires it.
+2. Restoring onto different infrastructure may require storage class mappings
+   and other transformations. Velero provides the mechanisms; your team must
+   design and test them.
+3. A backup phase of Completed means the backup operation completed. It does
+   not prove the application will start, contain the expected data, or serve
+   traffic. Only an end to end recovery test provides that evidence.
+
+**The question the audience asked:** "So Velero restored the namespace. Can
+it restore the whole infrastructure too?"
+
+No, and the boundary is worth memorizing. Velero's scope is selectable, from
+one namespace up to the entire cluster including cluster-scoped resources.
+But Velero restores resources into a cluster that already exists. It does not
+create the cluster, the nodes, the network, the load balancers, or DNS.
+Velero recovers what is inside Kubernetes. Something else must recover
+Kubernetes itself, and that something is infrastructure as code or Cluster
+API. If your DR plan starts with "restore the backup," ask what the backup
+gets restored into.
+
+## Demo 2: everything is green and the database is empty
+
+![The GitOps trap: Argo rebuilds the declarations, the vault holds the data](/img/blog/a-backup-is-not-disaster-recovery/gitops-trap.svg)
+
+This is the demo the room remembers. I recorded the time and powered off the
+production VM:
+
+```console
+$ date
+Sat Aug  8 12:09:33 IST 2026
+$ container stop kiac-drprod-control-plane
+kiac-drprod-control-plane
+
+$ kubectl --context kiac-drprod get nodes --request-timeout=4s
+Unable to connect to the server: net/http: request canceled while waiting
+for connection (Client.Timeout exceeded while awaiting headers)
+```
+
+Production is gone. Monitoring that lived in it is gone. What is left is the
+recovery cluster, which existed before the disaster, with its own Velero
+pointed at the same vault and Argo CD pointed at Git. Let's look at what it
+does not have:
+
+```console
+$ kubectl --context kind-dr-dr get namespaces
+NAME                 STATUS   AGE
+argocd               Active   12d
+default              Active   12d
+kube-node-lease      Active   12d
+kube-public          Active   12d
+kube-system          Active   12d
+ledger               Active   9d
+local-path-storage   Active   12d
+velero               Active   12d
+```
+
+No guestbook. This cluster has never run our app.
+
+Now the 2026 on-call reflex: we have GitOps, the whole app is declared in
+Git, just sync it. So I triggered Argo CD and waited for it to go green:
+
+```bash
+kubectl -n argocd patch application guestbook --type merge \
+  -p '{"operation":{"initiatedBy":{"username":"on-call"},"sync":{"revision":"HEAD"}}}'
+kubectl -n argocd wait application/guestbook \
+  --for=jsonpath='{.status.sync.status}'=Synced --timeout=300s
+kubectl -n guestbook rollout status statefulset/postgres --timeout 300s
+```
+
+```console
+application.argoproj.io/guestbook patched
+application.argoproj.io/guestbook condition met
+partitioned roll out complete: 1 new pods have been updated...
+
+NAME        SYNC STATUS   HEALTH STATUS
+guestbook   Synced        Progressing
+```
+
+Synced. Postgres Running and Ready. Every dashboard green. On stage I said
+this is the moment half the room posts "we are recovered" in Slack. Then I
+queried the data:
+
+```console
+$ kubectl -n guestbook exec statefulset/postgres -- \
+    psql -U postgres -d guestbook -c 'select * from attendees;'
+ERROR:  relation "attendees" does not exist
+LINE 1: select * from attendees;
+                      ^
+command terminated with exit code 1
+```
+
+The database is running and it is empty. Nothing malfunctioned. Git only ever
+contained the declarations, so Kubernetes did exactly what the YAML says:
+create a StatefulSet, create a Service, and provision a brand new, empty
+volume for the PVC. Git has never seen a single row of data. GitOps
+reconstructed the declared state perfectly and restored none of the stored
+state.
+
+**The question the audience asked:** "Why did we need Velero here if GitOps
+already brought the app back?"
+
+Because there were two different things to bring back and each tool carries
+exactly one of them: Git stores intent, and backups store state. The data
+existed in exactly one recoverable place, the Velero backup in the shared
+vault. So the real recovery is both tools in the right order:
+
+```console
+$ kubectl delete namespace guestbook --wait
+namespace "guestbook" deleted
+$ velero restore create --from-backup "$BACKUP" --wait
+Restore completed with status: Completed.
+$ kubectl -n guestbook exec statefulset/postgres -- \
+    psql -U postgres -d guestbook -c 'select * from attendees;'
+ id |  name  |            note
+----+--------+-----------------------------
+  1 | Priya  | came for the demos
+  2 | Marcus | still calls it swarm
+  3 | Chen   | has tested a restore. once.
+  4 | Fatima | owns the pager tonight
+(4 rows)
+$ date
+Sat Aug  8 12:11:28 IST 2026
+```
+
+Fatima is back, on a cluster that never ran the app, and even on different
+infrastructure: the backup was taken on a kiac VM and restored onto kind. A
+disaster may force you onto different infrastructure, so portability is
+something you test, not assume.
+
+Now the stopwatch. On stage, from powering off production to validated data
+in the recovery cluster took four minutes, 16:06 to 16:10 on the on-screen
+clock. The capture above, a rehearsed rerun, took just under two. The line I
+used on stage is the one I want you to keep: the first time we "recovered,"
+when the dashboards went green and the Slack message went out, was not the
+recovery. The second time, when the data came back and we checked it, was.
+And remember this measures only the scripted slice. A production RTO wraps
+detection, decision, traffic cutover, and failback around it.
+
+## Demo 3: two perfect snapshots, one broken application
+
+![Two snapshots from different moments tear the data](/img/blog/a-backup-is-not-disaster-recovery/torn-snapshots.svg)
+
+Real stateful applications span multiple volumes: database data plus WAL,
+Kafka brokers, replica sets. Our stand-in is a tiny ledger app writing
+matched pairs, order n to one PVC and payment n to another, five times a
+second. One invariant: every payment must have its order.
+
+I snapshotted the orders volume, let the app keep writing for five seconds,
+then snapshotted the payments volume. Each one is a plain CSI VolumeSnapshot,
+and 121152 is the run id the lab script stamps on every object in one run:
+
+```bash
+kubectl -n ledger apply -f - <<SNAP
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: torn-orders-121152
+spec:
+  volumeSnapshotClassName: csi-hostpath-snapclass
+  source:
+    persistentVolumeClaimName: orders-pvc
+SNAP
+sleep 5   # the app keeps writing matched pairs the whole time
+# then the identical VolumeSnapshot for payments-pvc, five seconds later
+```
+
+```console
+volumesnapshot.snapshot.storage.k8s.io/torn-orders-121152 created
+volumesnapshot.snapshot.storage.k8s.io/torn-orders-121152 condition met
+volumesnapshot.snapshot.storage.k8s.io/torn-payments-121152 created
+volumesnapshot.snapshot.storage.k8s.io/torn-payments-121152 condition met
+```
+
+Both ReadyToUse. Both individually perfect. Then I restored both into new
+PVCs using dataSource, the standard way to restore any CSI snapshot, and ran
+a verifier job that mounts both restored volumes and compares the last
+sequence number on each:
+
+```bash
+kubectl -n ledger apply -f - <<PVC
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: restored-torn-orders
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: csi-hostpath-sc
+  resources:
+    requests:
+      storage: 100Mi
+  dataSource:
+    apiGroup: snapshot.storage.k8s.io
+    kind: VolumeSnapshot
+    name: torn-orders-121152
+PVC
+# same PVC for the payments snapshot, then the verifier Job from the repo:
+# manifests/ledger/verify-job.tmpl.yaml
+```
+
+```console
+last order committed   : 108352
+last payment committed : 108377
+
+[FAIL] 25 payments have NO matching order.
+[FAIL] Each snapshot succeeded. The restore is still wrong.
+```
+
+Twenty five payments referencing orders that do not exist. Money moved for
+nothing. No component failed, every operation reported success, and the
+combined recovery point describes a moment in time that never existed. In
+production, that five second gap is simply your backup tool walking a list of
+a hundred PVCs one by one.
+
+The fix is a Kubernetes API that reached GA in 1.36 in April 2026:
+[VolumeGroupSnapshot](https://kubernetes.io/blog/2026/05/08/kubernetes-v1-36-volume-group-snapshot-ga/).
+One object selects the PVCs by label, and the CSI driver receives one request
+for a coordinated, crash consistent recovery point across all of them:
+
+```yaml
+apiVersion: groupsnapshot.storage.k8s.io/v1
+kind: VolumeGroupSnapshot
+metadata:
+  name: ledger-group-snap
+spec:
+  volumeGroupSnapshotClassName: csi-hostpath-groupsnapclass
+  source:
+    selector:
+      matchLabels:
+        group: ledger
+```
+
+![One group snapshot cuts both volumes at the same moment](/img/blog/a-backup-is-not-disaster-recovery/group-snapshot.svg)
+
+The group request produces managed member snapshots, one per volume, from a
+single point in time:
+
+```console
+volumegroupsnapshot.groupsnapshot.storage.k8s.io/group-121152 created
+volumegroupsnapshot.groupsnapshot.storage.k8s.io/group-121152 condition met
+
+NAME               GROUP          READY
+snapshot-63f367... group-121152   true
+snapshot-c3a36e... group-121152   true
+```
+
+The member snapshots are auto-named; find them through the group they belong
+to, then restore them exactly like the individual snapshots above and run the
+same verifier:
+
+```bash
+kubectl -n ledger get volumesnapshot \
+  -o custom-columns='NAME:.metadata.name,GROUP:.status.volumeGroupSnapshotName,READY:.status.readyToUse'
+# restore each member with a dataSource PVC, run the verifier again
+```
+
+```console
+last order committed   : 109169
+last payment committed : 109169
+
+[OK] Every payment has a matching order. Restore is consistent.
+```
+
+Full disclosure, the same one I gave on stage: my lab uses the CSI hostpath
+test driver, which implements the group RPCs but archives member volumes
+sequentially, so the writer is paused during the group snapshot to keep the
+demo deterministic. What the demo shows is the GA API and the restore
+workflow. The same point in time guarantee itself belongs to the storage
+backend of a production driver. Which leads to the practical takeaways:
+
+- Support is driver specific. A driver that supports ordinary
+  VolumeSnapshots proves nothing about group snapshots. Ask your storage
+  vendor whether they implement the CSI group RPCs. As of mid 2026, most of
+  the major cloud drivers I checked do not.
+- Setup is explicit: the CRDs and feature gates on the snapshot controller
+  and CSI sidecar are your job.
+- Crash consistent is not application consistent. The API removes cross
+  volume timing skew. It does not flush or quiesce your database.
+
+## What is still broken
+
+The demos expose gaps that no single tool closes today:
+
+1. **No common cross-cluster failover contract.** Data, workload, cluster,
+   traffic, and identity all have tools, and every row is missing the same
+   thing: a shared contract with the next row. Products answer this inside
+   their own APIs; core Kubernetes does not define the sequence.
+2. **No standard recovery unit for an application.** Core Kubernetes has no
+   maintained Application resource that says which objects, operators, data
+   services, and external dependencies must recover together. Velero uses
+   namespaces and labels, Argo has Applications, Helm has releases, and each
+   draws the boundary differently.
+3. **Backup success is treated as recovery proof.** Some teams test
+   resilience by deleting a pod and watching it return. That tests workload
+   reconciliation, not recovery. A recovery test restores into a clean
+   target, validates data and the user path, and measures the whole thing.
+
+There is community work here: the Cloud Native Business Continuity initiative
+proposal under CNCF TAG Operational Resilience (disclosure: I am one of the
+TAG chairs). It is an open proposal seeking contributors, aiming at a
+landscape gap analysis, updated backup and DR guidance, and reference
+architectures. If this post resonates, that is where to help:
+https://github.com/cncf/toc/issues/1779
+
+## From a laptop to production
+
+![Two independent failure domains](/img/blog/a-backup-is-not-disaster-recovery/prod-dr.svg)
+
+Every piece of the lab is a stand-in. The kiac cluster is your active region.
+The kind cluster is your recovery region, account, or second provider.
+SeaweedFS is a cross region S3 bucket or offsite object store. Gitea is the
+Git and infrastructure config that must survive the disaster. Powering off
+the VM is the region loss. The principles that transfer as-is: recovery
+points outside the failure domain, a recovery target that exists before the
+disaster, restore order, and application level validation. The exact failure
+modes and timings still need testing on your production platforms.
+
+## Now the questions are for you
+
+We ended the talk with questions instead of answers, and I will end this post
+the same way. Answer these honestly, ideally out loud in your next team
+meeting:
+
+1. Are you treating backup as DR? Backup answers "where is my data." DR
+   answers "how fast am I serving traffic again, and who does what at 2 AM."
+   If your entire DR plan fits inside a Velero schedule, you have a backup
+   plan.
+2. Who owns your Kubernetes DR, end to end, by name? Platform backs up the
+   cluster, the app team assumes the platform handles it, the DBA asks which
+   cluster. If ownership stops at team boundaries, nobody owns recovery.
+3. When did your team last restore a complete stateful application into a
+   clean cluster, validate the data, and time it? Restored, not just backed
+   up.
+4. Can you state RPO and RTO for your most critical application, and has a
+   stopwatch ever confirmed the RTO?
+5. Do your multi volume applications have one coordinated recovery point, or
+   a pile of individually perfect snapshots from different moments?
+6. If your region disappeared right now, do your Git repos, secrets, and
+   backups survive it, or do they live in the blast radius?
+
+If any answer made you uncomfortable, the fix is one rehearsal, not a new
+tool: pick one stateful app this month, restore it into a clean cluster,
+validate the data and the user path, and write down the time. Turn the guess
+into a number. That is the whole difference between having backups and having
+disaster recovery, and it is the difference between Fatima's night ending in
+panic or ending in a runbook she has already executed.
+
+The lab, the commands, and everything you saw here:
+https://github.com/saiyam1814/kubecon-japan-dr-demo
+
+I would genuinely like to hear what you do today: who owns DR at your
+company, and when did you last run a real restore? Tell me on
+[X](https://x.com/saiyampathak) or
+[LinkedIn](https://linkedin.com/in/saiyampathak).

--- a/public/img/blog/a-backup-is-not-disaster-recovery/gitops-trap.svg
+++ b/public/img/blog/a-backup-is-not-disaster-recovery/gitops-trap.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 940 360" style="font-family:'Chalkboard SE','Comic Sans MS',cursive">
+  <defs>
+    <pattern id="hred" width="9" height="9" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
+      <line x1="0" y1="0" x2="0" y2="9" stroke="#FFC9C9" stroke-width="4"/>
+    </pattern>
+    <pattern id="hgreen" width="9" height="9" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
+      <line x1="0" y1="0" x2="0" y2="9" stroke="#D3F9D8" stroke-width="4"/>
+    </pattern>
+    <pattern id="hyellow" width="9" height="9" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
+      <line x1="0" y1="0" x2="0" y2="9" stroke="#FFF3BF" stroke-width="4"/>
+    </pattern>
+  </defs>
+  <g stroke="#1e1e1e" stroke-width="2.4" fill="none" stroke-linecap="round" stroke-linejoin="round">
+
+    <!-- dead prod -->
+    <g transform="rotate(-0.5 130 150)">
+      <path d="M48 84 Q130 78 212 84 Q218 150 212 218 Q130 224 48 218 Q42 150 48 84 Z" fill="url(#hred)"/>
+    </g>
+    <path d="M62 96 Q130 160 200 208" stroke="#E03131" stroke-width="5"/>
+    <path d="M198 98 Q132 158 64 206" stroke="#E03131" stroke-width="5"/>
+
+    <!-- git cylinder top middle -->
+    <path d="M380 40 Q440 32 500 40 L497 74 Q440 82 383 74 Z" fill="url(#hyellow)"/>
+    <path d="M380 40 Q440 50 500 40"/>
+    <!-- arrow git -> recovery -->
+    <path d="M508 64 Q600 84 664 116" stroke="#1971C2" stroke-width="3.2"/>
+    <path d="M646 104 Q656 111 664 116 Q657 122 650 129" stroke="#1971C2" stroke-width="3.2"/>
+
+    <!-- recovery cluster -->
+    <g transform="rotate(0.4 780 170)">
+      <path d="M620 108 Q780 100 916 108 Q924 170 916 234 Q780 242 620 234 Q612 170 620 108 Z" fill="url(#hgreen)"/>
+    </g>
+    <!-- db cylinder inside, empty with ? -->
+    <path d="M726 142 Q772 135 818 142 L816 196 Q772 203 728 196 Z" fill="#fff"/>
+    <path d="M726 142 Q772 151 818 142"/>
+    <!-- green check top right of cluster -->
+    <path d="M856 76 Q866 90 872 100 Q888 68 912 50" stroke="#2F9E44" stroke-width="5"/>
+
+    <!-- vault bottom middle -->
+    <path d="M400 240 Q448 232 496 240 L484 330 Q448 338 414 330 Z" fill="url(#hyellow)"/>
+    <path d="M400 240 Q448 250 496 240"/>
+    <!-- arrow prod -> vault (backup happened before disaster, dashed grey) -->
+    <path d="M220 210 Q300 250 394 268" stroke="#868e96" stroke-width="3" stroke-dasharray="7 6"/>
+    <path d="M377 256 Q386 263 394 268 Q385 271 376 276" stroke="#868e96" stroke-width="3"/>
+    <!-- arrow vault -> recovery (the real restore) -->
+    <path d="M502 276 Q600 262 662 220" stroke="#E8590C" stroke-width="3.4"/>
+    <path d="M646 214 Q654 217 662 220 Q658 228 655 237" stroke="#E8590C" stroke-width="3.4"/>
+  </g>
+
+  <text x="130" y="252" text-anchor="middle" font-size="18" fill="#1e1e1e">prod · powered off</text>
+  <text x="440" y="24" text-anchor="middle" font-size="16" fill="#1e1e1e">Git · the declarations</text>
+  <text x="600" y="66" text-anchor="middle" font-size="14" fill="#1971C2">Argo syncs · green in 30s</text>
+  <text x="772" y="176" text-anchor="middle" font-size="26" fill="#E03131">?</text>
+  <text x="772" y="266" text-anchor="middle" font-size="15" fill="#E03131">running · and EMPTY</text>
+  <text x="780" y="290" text-anchor="middle" font-size="17" fill="#1e1e1e">recovery cluster</text>
+  <text x="448" y="354" text-anchor="middle" font-size="15" fill="#1e1e1e">S3 vault · the only place the data survived</text>
+  <text x="300" y="216" text-anchor="middle" font-size="13" fill="#868e96">backup · before the disaster</text>
+  <text x="600" y="300" text-anchor="middle" font-size="15" fill="#E8590C">Velero restore · the missing step</text>
+</svg>

--- a/public/img/blog/a-backup-is-not-disaster-recovery/group-snapshot.svg
+++ b/public/img/blog/a-backup-is-not-disaster-recovery/group-snapshot.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -14 860 264" style="font-family:'Chalkboard SE','Comic Sans MS',cursive">
+  <defs>
+    <pattern id="hblue" width="9" height="9" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
+      <line x1="0" y1="0" x2="0" y2="9" stroke="#D0EBFF" stroke-width="4"/>
+    </pattern>
+    <pattern id="hgreen" width="9" height="9" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
+      <line x1="0" y1="0" x2="0" y2="9" stroke="#D3F9D8" stroke-width="4"/>
+    </pattern>
+  </defs>
+  <g stroke="#1e1e1e" stroke-width="2.4" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <!-- lasso around both volumes -->
+    <path d="M46 26 Q120 18 196 26 Q206 120 196 216 Q120 226 48 216 Q38 120 46 26 Z" stroke="#E8590C" stroke-width="3" stroke-dasharray="10 8"/>
+    <!-- volumes -->
+    <path d="M74 48 Q120 41 166 48 L164 92 Q120 99 76 92 Z" fill="url(#hblue)"/>
+    <path d="M74 48 Q120 57 166 48"/>
+    <path d="M74 150 Q120 143 166 150 L164 194 Q120 201 76 194 Z" fill="url(#hgreen)"/>
+    <path d="M74 150 Q120 159 166 150"/>
+    <!-- write lanes -->
+    <path d="M212 70 Q440 64 700 69"/>
+    <path d="M212 172 Q440 166 700 171"/>
+    <!-- single cut across both -->
+    <line x1="480" y1="34" x2="480" y2="204" stroke-dasharray="6 6" stroke="#E8590C" stroke-width="3.4"/>
+    <!-- one camera -->
+    <path d="M454 6 Q480 2 506 6 L506 32 Q480 36 454 32 Z" fill="#FFD8A8"/>
+    <path d="M472 6 L476 -2 L490 -2 L494 6"/>
+    <!-- check -->
+    <path d="M726 96 Q740 116 750 130 Q772 84 806 56" stroke="#2F9E44" stroke-width="6"/>
+  </g>
+  <text x="120" y="242" text-anchor="middle" font-size="15" fill="#E8590C">selector: group=ledger</text>
+  <text x="560" y="30" text-anchor="start" font-size="16" fill="#E8590C">one cut · one moment · both volumes</text>
+  <text x="766" y="160" text-anchor="middle" font-size="16" fill="#2F9E44">crash-consistent</text>
+</svg>

--- a/public/img/blog/a-backup-is-not-disaster-recovery/lab-setup.svg
+++ b/public/img/blog/a-backup-is-not-disaster-recovery/lab-setup.svg
@@ -1,0 +1,81 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 940 430" style="font-family:'Chalkboard SE','Comic Sans MS',cursive">
+  <defs>
+    <pattern id="hblue" width="9" height="9" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
+      <line x1="0" y1="0" x2="0" y2="9" stroke="#D0EBFF" stroke-width="4"/>
+    </pattern>
+    <pattern id="hgreen" width="9" height="9" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
+      <line x1="0" y1="0" x2="0" y2="9" stroke="#D3F9D8" stroke-width="4"/>
+    </pattern>
+    <pattern id="hyellow" width="9" height="9" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
+      <line x1="0" y1="0" x2="0" y2="9" stroke="#FFF3BF" stroke-width="4"/>
+    </pattern>
+  </defs>
+  <g stroke="#1e1e1e" stroke-width="2.4" fill="none" stroke-linecap="round" stroke-linejoin="round">
+
+    <!-- Gitea, top center -->
+    <path d="M400 30 Q470 22 540 30 L536 66 Q470 74 404 66 Z" fill="url(#hyellow)"/>
+    <path d="M400 30 Q470 40 540 30"/>
+    <!-- arrow gitea -> DR (argo pulls) -->
+    <path d="M548 58 Q640 76 700 108" stroke="#1971C2" stroke-width="3"/>
+    <path d="M682 96 Q692 103 700 108 Q693 113 686 120" stroke="#1971C2" stroke-width="3"/>
+
+    <!-- PROD: kiac, VM wall drawn as double border -->
+    <g transform="rotate(-0.4 190 220)">
+      <path d="M52 118 Q190 110 328 118 Q336 220 328 322 Q190 330 52 322 Q44 220 52 118 Z" fill="url(#hblue)"/>
+      <path d="M64 130 Q190 123 316 130 Q323 220 316 310 Q190 317 64 310 Q57 220 64 130 Z" stroke-dasharray="3 6"/>
+    </g>
+    <!-- postgres cylinder + pv -->
+    <path d="M120 176 Q166 169 212 176 L210 224 Q166 231 122 224 Z" fill="#fff"/>
+    <path d="M120 176 Q166 185 212 176"/>
+    <!-- velero sail tag -->
+    <path d="M236 168 L236 226 Q262 214 288 226 L288 168 Q262 156 236 168 Z" fill="#fff" transform="rotate(2 262 196)"/>
+    <path d="M252 184 Q262 178 274 184" stroke-width="2"/>
+    <path d="M250 200 Q262 194 276 200" stroke-width="2"/>
+
+    <!-- DR: kind -->
+    <g transform="rotate(0.4 750 220)">
+      <path d="M612 118 Q750 110 888 118 Q896 220 888 322 Q750 330 612 322 Q604 220 612 118 Z" fill="url(#hgreen)"/>
+    </g>
+    <!-- argo octopus-ish head -->
+    <path d="M652 170 Q676 158 698 170 Q706 188 692 198 Q676 206 660 198 Q646 188 652 170 Z" fill="#fff"/>
+    <path d="M660 202 L656 216 M676 205 L676 219 M692 202 L696 216" stroke-width="2"/>
+    <!-- ledger: two small cylinders -->
+    <path d="M740 176 Q766 172 792 176 L790 206 Q766 210 742 206 Z" fill="#fff"/>
+    <path d="M740 176 Q766 182 792 176"/>
+    <path d="M810 176 Q836 172 862 176 L860 206 Q836 210 812 206 Z" fill="#fff"/>
+    <path d="M810 176 Q836 182 862 176"/>
+    <!-- velero sail tag DR -->
+    <path d="M700 242 L700 296 Q724 285 748 296 L748 242 Q724 231 700 242 Z" fill="#fff" transform="rotate(-2 724 268)"/>
+    <path d="M714 258 Q724 252 736 258" stroke-width="2"/>
+    <path d="M712 274 Q724 268 738 274" stroke-width="2"/>
+
+    <!-- vault, bottom center -->
+    <path d="M424 296 Q470 288 516 296 L504 392 Q470 400 436 392 Z" fill="url(#hyellow)"/>
+    <path d="M424 296 Q470 306 516 296"/>
+    <!-- backup arrow prod -> vault (through the VM wall) -->
+    <path d="M334 268 Q380 296 418 320" stroke="#E8590C" stroke-width="3.2"/>
+    <path d="M402 306 Q410 314 418 320 Q408 322 399 327" stroke="#E8590C" stroke-width="3.2"/>
+    <!-- restore arrow vault -> DR (dashed) -->
+    <path d="M522 320 Q560 296 606 268" stroke="#E8590C" stroke-width="3.2" stroke-dasharray="8 7"/>
+    <path d="M588 268 Q598 267 606 268 Q601 276 598 285" stroke="#E8590C" stroke-width="3.2"/>
+  </g>
+
+  <text x="470" y="54" text-anchor="middle" font-size="17" fill="#1e1e1e">Gitea · app YAML in Git</text>
+  <text x="648" y="66" text-anchor="middle" font-size="13" fill="#1971C2">Argo pulls</text>
+
+  <text x="166" y="256" text-anchor="middle" font-size="15" fill="#1e1e1e">Postgres + PV</text>
+  <text x="264" y="256" text-anchor="middle" font-size="15" fill="#1e1e1e">Velero</text>
+  <text x="190" y="298" text-anchor="middle" font-size="15" fill="#5f5b53">+ CSI snapshots · VGS</text>
+  <text x="190" y="356" text-anchor="middle" font-size="19" fill="#1e1e1e">prod · kiac</text>
+  <text x="190" y="378" text-anchor="middle" font-size="14" fill="#5f5b53">the node is its own VM</text>
+
+  <text x="676" y="232" text-anchor="middle" font-size="15" fill="#1e1e1e">Argo CD</text>
+  <text x="800" y="232" text-anchor="middle" font-size="15" fill="#1e1e1e">ledger · 2 PVCs</text>
+  <text x="724" y="318" text-anchor="middle" font-size="15" fill="#1e1e1e">Velero</text>
+  <text x="750" y="356" text-anchor="middle" font-size="19" fill="#1e1e1e">recovery · kind</text>
+  <text x="750" y="378" text-anchor="middle" font-size="14" fill="#5f5b53">+ CSI snapshots · VGS</text>
+
+  <text x="370" y="308" text-anchor="end" font-size="14" fill="#E8590C">backup</text>
+  <text x="572" y="308" text-anchor="start" font-size="14" fill="#E8590C">restore</text>
+  <text x="470" y="418" text-anchor="middle" font-size="16" fill="#1e1e1e">SeaweedFS · S3 vault outside both clusters</text>
+</svg>

--- a/public/img/blog/a-backup-is-not-disaster-recovery/layers.svg
+++ b/public/img/blog/a-backup-is-not-disaster-recovery/layers.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 330" style="font-family:'Chalkboard SE','Comic Sans MS',cursive">
+  <defs>
+    <pattern id="hviolet" width="9" height="9" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
+      <line x1="0" y1="0" x2="0" y2="9" stroke="#E5DBFF" stroke-width="4"/>
+    </pattern>
+    <pattern id="hblue" width="9" height="9" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
+      <line x1="0" y1="0" x2="0" y2="9" stroke="#D0EBFF" stroke-width="4"/>
+    </pattern>
+    <pattern id="hgreen" width="9" height="9" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
+      <line x1="0" y1="0" x2="0" y2="9" stroke="#D3F9D8" stroke-width="4"/>
+    </pattern>
+    <pattern id="hyellow" width="9" height="9" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
+      <line x1="0" y1="0" x2="0" y2="9" stroke="#FFF3BF" stroke-width="4"/>
+    </pattern>
+  </defs>
+  <g stroke="#1e1e1e" stroke-width="2.4" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <g transform="rotate(-0.5 340 69)">
+      <path d="M64 44 Q340 38 616 44 Q621 68 616 94 Q340 100 64 94 Q59 68 64 44 Z" fill="url(#hviolet)"/>
+    </g>
+    <g transform="rotate(0.4 340 139)">
+      <path d="M58 114 Q340 109 622 114 Q626 138 622 164 Q340 169 58 164 Q54 138 58 114 Z" fill="url(#hblue)"/>
+    </g>
+    <g transform="rotate(-0.35 340 209)">
+      <path d="M66 184 Q340 179 614 184 Q619 208 614 234 Q340 240 66 234 Q61 208 66 184 Z" fill="url(#hgreen)"/>
+    </g>
+    <g transform="rotate(0.5 340 279)">
+      <path d="M60 254 Q340 249 620 254 Q625 278 620 304 Q340 310 60 304 Q55 278 60 254 Z" fill="url(#hyellow)"/>
+    </g>
+    <!-- arrows pointing at the joins -->
+    <path d="M760 128 Q700 118 648 104" stroke="#E8590C" stroke-width="3"/>
+    <path d="M664 96 Q656 100 648 104 Q652 111 657 118" stroke="#E8590C" stroke-width="3"/>
+    <path d="M760 176 Q700 176 648 174" stroke="#E8590C" stroke-width="3"/>
+    <path d="M664 166 Q656 170 648 174 Q655 179 663 183" stroke="#E8590C" stroke-width="3"/>
+    <path d="M760 224 Q700 234 648 244" stroke="#E8590C" stroke-width="3"/>
+    <path d="M662 232 Q655 238 648 244 Q655 249 664 253" stroke="#E8590C" stroke-width="3"/>
+  </g>
+  <text x="86" y="78" font-size="21" fill="#1e1e1e">1 · cluster state</text>
+  <text x="300" y="78" font-size="16" fill="#5f5b53">etcd, API objects, the control plane itself</text>
+  <text x="86" y="148" font-size="21" fill="#1e1e1e">2 · app definitions</text>
+  <text x="320" y="148" font-size="16" fill="#5f5b53">YAML, Helm charts, the Git repo</text>
+  <text x="86" y="218" font-size="21" fill="#1e1e1e">3 · persistent data</text>
+  <text x="320" y="218" font-size="16" fill="#5f5b53">PVs, databases, object stores</text>
+  <text x="86" y="288" font-size="21" fill="#1e1e1e">4 · access &amp; traffic</text>
+  <text x="316" y="288" font-size="16" fill="#5f5b53">secrets, certs, DNS, external services</text>
+  <text x="775" y="168" font-size="21" fill="#E8590C">recovery</text>
+  <text x="775" y="192" font-size="21" fill="#E8590C">fails at</text>
+  <text x="775" y="216" font-size="21" fill="#E8590C">the joins</text>
+</svg>

--- a/public/img/blog/a-backup-is-not-disaster-recovery/prod-dr.svg
+++ b/public/img/blog/a-backup-is-not-disaster-recovery/prod-dr.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 940 340" style="font-family:'Chalkboard SE','Comic Sans MS',cursive">
+  <defs>
+    <pattern id="hblue" width="9" height="9" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
+      <line x1="0" y1="0" x2="0" y2="9" stroke="#D0EBFF" stroke-width="4"/>
+    </pattern>
+    <pattern id="hgreen" width="9" height="9" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
+      <line x1="0" y1="0" x2="0" y2="9" stroke="#D3F9D8" stroke-width="4"/>
+    </pattern>
+    <pattern id="hyellow" width="9" height="9" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
+      <line x1="0" y1="0" x2="0" y2="9" stroke="#FFF3BF" stroke-width="4"/>
+    </pattern>
+  </defs>
+  <g stroke="#1e1e1e" stroke-width="2.4" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <!-- git/iac/secrets outside both -->
+    <path d="M336 22 Q460 16 586 22 Q590 52 586 84 Q460 90 336 84 Q332 52 336 22 Z" fill="url(#hyellow)"/>
+    <path d="M330 88 Q250 104 210 128" stroke="#1971C2"/>
+    <path d="M228 116 Q218 123 210 128 Q216 134 224 141" stroke="#1971C2"/>
+    <path d="M592 88 Q672 104 712 128" stroke="#1971C2"/>
+    <path d="M694 116 Q704 123 712 128 Q706 134 698 141" stroke="#1971C2"/>
+    <!-- Site A -->
+    <path d="M76 134 Q192 128 308 134 Q313 200 308 268 Q192 274 76 268 Q71 200 76 134 Z" fill="url(#hblue)"/>
+    <!-- Site B -->
+    <path d="M612 134 Q728 128 844 134 Q849 200 844 268 Q728 274 612 268 Q607 200 612 134 Z" fill="url(#hgreen)"/>
+    <!-- db replication -->
+    <path d="M322 172 Q460 156 598 172" stroke="#E8590C" stroke-width="3.2"/>
+    <path d="M580 160 Q590 167 598 172 Q591 178 584 185" stroke="#E8590C" stroke-width="3.2"/>
+    <!-- backup vault outside A -->
+    <path d="M410 244 Q458 238 506 244 L494 316 Q458 324 424 316 Z" fill="url(#hyellow)"/>
+    <path d="M410 244 Q458 254 506 244"/>
+    <path d="M312 258 Q356 268 402 274" stroke="#E8590C" stroke-width="3"/>
+    <path d="M386 262 Q394 269 402 274 Q393 278 384 283" stroke="#E8590C" stroke-width="3"/>
+    <path d="M514 274 Q560 268 604 258" stroke="#E8590C" stroke-width="3" stroke-dasharray="8 7"/>
+    <path d="M588 250 Q596 254 604 258 Q598 264 593 271" stroke="#E8590C" stroke-width="3"/>
+    <!-- users -->
+    <path d="M898 158 Q908 154 912 162 Q916 172 906 176 Q896 178 894 168 Q893 160 898 158 Z"/>
+    <line x1="903" y1="178" x2="903" y2="206"/>
+    <line x1="903" y1="186" x2="888" y2="198"/><line x1="903" y1="186" x2="918" y2="198"/>
+    <line x1="903" y1="206" x2="890" y2="226"/><line x1="903" y1="206" x2="916" y2="226"/>
+    <path d="M884 200 Q862 196 850 190" stroke="#2F9E44" stroke-width="3" stroke-dasharray="7 6"/>
+  </g>
+  <text x="460" y="48" text-anchor="middle" font-size="19" fill="#1e1e1e">Git · IaC · secrets</text>
+  <text x="460" y="72" text-anchor="middle" font-size="14" fill="#5f5b53">outside both sites</text>
+  <text x="192" y="298" text-anchor="middle" font-size="18" fill="#1e1e1e">Site A · active</text>
+  <text x="728" y="298" text-anchor="middle" font-size="18" fill="#1e1e1e">Site B · warm</text>
+  <text x="460" y="146" text-anchor="middle" font-size="15" fill="#E8590C">database replication</text>
+  <text x="368" y="302" text-anchor="end" font-size="14" fill="#E8590C">backup</text>
+  <text x="548" y="302" text-anchor="start" font-size="14" fill="#E8590C">restore</text>
+  <text x="458" y="336" text-anchor="middle" font-size="15" fill="#1e1e1e">recovery vault · outside Site A</text>
+  <text x="884" y="242" text-anchor="middle" font-size="13" fill="#2F9E44">traffic, after</text>
+  <text x="884" y="260" text-anchor="middle" font-size="13" fill="#2F9E44">validation</text>
+</svg>

--- a/public/img/blog/a-backup-is-not-disaster-recovery/rpo-rto.svg
+++ b/public/img/blog/a-backup-is-not-disaster-recovery/rpo-rto.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 280" style="font-family:'Chalkboard SE','Comic Sans MS',cursive">
+  <g stroke="#1e1e1e" stroke-width="2.4" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <!-- timeline -->
+    <path d="M55 162 Q280 156 480 161 Q680 165 845 159"/>
+    <path d="M826 150 Q836 155 845 159 Q834 163 825 169"/>
+    <!-- camera: last good recovery point -->
+    <path d="M196 122 Q220 118 244 122 L244 150 Q220 154 196 150 Z" fill="#A5D8FF"/>
+    <path d="M212 122 L216 112 L228 112 L232 122"/>
+    <path d="M214 136 Q220 130 227 135 Q230 142 222 145 Q214 144 214 136 Z" fill="#fff"/>
+    <line x1="220" y1="152" x2="220" y2="162"/>
+    <!-- explosion at disaster -->
+    <path d="M470 118 L479 136 L500 130 L488 147 L506 158 L484 160 L487 180 L470 166 L453 180 L456 160 L434 158 L452 147 L440 130 L461 136 Z" fill="#FFC9C9" stroke="#E03131"/>
+    <!-- flag: serving again -->
+    <line x1="760" y1="112" x2="760" y2="160"/>
+    <path d="M760 112 Q784 118 806 112 L804 134 Q782 140 760 134 Z" fill="#B2F2BB" stroke="#2F9E44"/>
+    <!-- RPO bracket -->
+    <path d="M220 108 L220 92 Q345 84 470 92 L470 108" stroke="#E8590C"/>
+    <!-- RTO bracket -->
+    <path d="M470 214 L470 230 Q615 238 760 230 L760 214" stroke="#E8590C"/>
+  </g>
+  <text x="220" y="196" text-anchor="middle" font-size="17" fill="#1e1e1e">last good recovery point</text>
+  <text x="470" y="216" text-anchor="middle" font-size="17" fill="#E03131">02:07 · disaster</text>
+  <text x="760" y="196" text-anchor="middle" font-size="17" fill="#1e1e1e">serving users again</text>
+  <text x="345" y="72" text-anchor="middle" font-size="20" fill="#E8590C">RPO · the data you lose</text>
+  <text x="615" y="262" text-anchor="middle" font-size="20" fill="#E8590C">RTO · the time you are down</text>
+</svg>

--- a/public/img/blog/a-backup-is-not-disaster-recovery/torn-snapshots.svg
+++ b/public/img/blog/a-backup-is-not-disaster-recovery/torn-snapshots.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 310" style="font-family:'Chalkboard SE','Comic Sans MS',cursive">
+  <defs>
+    <pattern id="hblue" width="9" height="9" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
+      <line x1="0" y1="0" x2="0" y2="9" stroke="#D0EBFF" stroke-width="4"/>
+    </pattern>
+    <pattern id="hgreen" width="9" height="9" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
+      <line x1="0" y1="0" x2="0" y2="9" stroke="#D3F9D8" stroke-width="4"/>
+    </pattern>
+    <pattern id="hredx" width="8" height="8" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
+      <line x1="0" y1="0" x2="0" y2="8" stroke="#FFA8A8" stroke-width="3.4"/>
+    </pattern>
+  </defs>
+  <g stroke="#1e1e1e" stroke-width="2.4" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <!-- orders volume + write lane -->
+    <path d="M64 70 Q114 62 164 70 L162 120 Q114 128 66 120 Z" fill="url(#hblue)"/>
+    <path d="M64 70 Q114 80 164 70"/>
+    <path d="M180 96 Q480 90 810 95"/>
+    <line x1="240" y1="88" x2="240" y2="104"/><line x1="300" y1="88" x2="300" y2="104"/><line x1="360" y1="88" x2="360" y2="104"/><line x1="470" y1="88" x2="470" y2="104"/><line x1="530" y1="88" x2="530" y2="104"/><line x1="590" y1="88" x2="590" y2="104"/><line x1="650" y1="88" x2="650" y2="104"/><line x1="710" y1="88" x2="710" y2="104"/>
+    <!-- payments volume + write lane -->
+    <path d="M64 190 Q114 182 164 190 L162 240 Q114 248 66 240 Z" fill="url(#hgreen)"/>
+    <path d="M64 190 Q114 200 164 190"/>
+    <path d="M180 216 Q480 210 810 215"/>
+    <line x1="240" y1="208" x2="240" y2="224"/><line x1="300" y1="208" x2="300" y2="224"/><line x1="360" y1="208" x2="360" y2="224"/><line x1="470" y1="208" x2="470" y2="224"/><line x1="530" y1="208" x2="530" y2="224"/><line x1="590" y1="208" x2="590" y2="224"/><line x1="650" y1="208" x2="650" y2="224"/><line x1="710" y1="208" x2="710" y2="224"/>
+    <!-- camera snap on orders at t=0 -->
+    <path d="M382 30 Q406 26 430 30 L430 58 Q406 62 382 58 Z" fill="#A5D8FF"/>
+    <path d="M398 30 L402 20 L414 20 L418 30"/>
+    <line x1="406" y1="64" x2="406" y2="112" stroke-dasharray="6 6" stroke="#1971C2" stroke-width="3"/>
+    <!-- camera snap on payments at t=5 -->
+    <path d="M596 262 Q620 258 644 262 L644 290 Q620 294 596 290 Z" fill="#B2F2BB"/>
+    <path d="M612 262 L616 252 L628 252 L632 262"/>
+    <line x1="620" y1="196" x2="620" y2="256" stroke-dasharray="6 6" stroke="#2F9E44" stroke-width="3"/>
+    <!-- the skew window on the payments lane -->
+    <path d="M408 200 L618 200 L618 232 L408 232 Z" fill="url(#hredx)" stroke="#E03131" stroke-dasharray="5 5"/>
+  </g>
+  <text x="114" y="52" text-anchor="middle" font-size="17" fill="#1e1e1e">orders PV</text>
+  <text x="114" y="270" text-anchor="middle" font-size="17" fill="#1e1e1e">payments PV</text>
+  <text x="330" y="44" text-anchor="end" font-size="16" fill="#1971C2">snapshot A · t = 0</text>
+  <text x="700" y="280" text-anchor="start" font-size="16" fill="#2F9E44">snapshot B · t = 5s</text>
+  <text x="513" y="180" text-anchor="middle" font-size="17" fill="#E03131">5 seconds of payments with no matching order</text>
+</svg>

--- a/public/img/blog/a-backup-is-not-disaster-recovery/velero-flow.svg
+++ b/public/img/blog/a-backup-is-not-disaster-recovery/velero-flow.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 250" style="font-family:'Chalkboard SE','Comic Sans MS',cursive">
+  <defs>
+    <pattern id="hblue" width="9" height="9" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
+      <line x1="0" y1="0" x2="0" y2="9" stroke="#D0EBFF" stroke-width="4"/>
+    </pattern>
+    <pattern id="hyellow" width="9" height="9" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
+      <line x1="0" y1="0" x2="0" y2="9" stroke="#FFF3BF" stroke-width="4"/>
+    </pattern>
+    <pattern id="hgreen" width="9" height="9" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
+      <line x1="0" y1="0" x2="0" y2="9" stroke="#D3F9D8" stroke-width="4"/>
+    </pattern>
+  </defs>
+  <g stroke="#1e1e1e" stroke-width="2.4" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <!-- source cluster -->
+    <path d="M62 62 Q160 56 258 62 Q263 125 258 190 Q160 196 62 190 Q57 125 62 62 Z" fill="url(#hblue)"/>
+    <rect x="86" y="84" width="34" height="30" rx="5" fill="#fff" transform="rotate(-1.6 103 99)"/>
+    <rect x="132" y="82" width="34" height="30" rx="5" fill="#fff" transform="rotate(1.4 149 97)"/>
+    <path d="M96 136 Q130 128 164 136 L162 166 Q130 174 98 166 Z" fill="#fff"/>
+    <path d="M96 136 Q130 144 164 136"/>
+    <!-- backup arrow -->
+    <path d="M272 122 Q322 112 372 122" stroke="#E8590C" stroke-width="3.2"/>
+    <path d="M354 108 Q364 116 372 122 Q361 126 351 132" stroke="#E8590C" stroke-width="3.2"/>
+    <!-- bucket -->
+    <path d="M394 84 Q444 78 494 84 L480 192 Q444 200 408 192 Z" fill="url(#hyellow)"/>
+    <path d="M394 84 Q444 94 494 84"/>
+    <!-- restore arrow (dashed) -->
+    <path d="M510 122 Q560 112 610 122" stroke="#E8590C" stroke-width="3.2" stroke-dasharray="8 7"/>
+    <path d="M592 108 Q602 116 610 122 Q599 126 589 132" stroke="#E8590C" stroke-width="3.2"/>
+    <!-- target cluster (dashed = does not exist yet) -->
+    <path d="M628 62 Q726 56 824 62 Q829 125 824 190 Q726 196 628 190 Q623 125 628 62 Z" fill="url(#hgreen)" stroke-dasharray="9 7"/>
+    <path d="M700 116 Q712 132 720 142 Q740 104 766 84" stroke="#2F9E44" stroke-width="5"/>
+  </g>
+  <text x="160" y="218" text-anchor="middle" font-size="18" fill="#1e1e1e">source cluster</text>
+  <text x="322" y="94" text-anchor="middle" font-size="16" fill="#E8590C">objects + PV bytes</text>
+  <text x="444" y="224" text-anchor="middle" font-size="18" fill="#1e1e1e">any S3 vault</text>
+  <text x="560" y="94" text-anchor="middle" font-size="16" fill="#E8590C">restore</text>
+  <text x="726" y="218" text-anchor="middle" font-size="18" fill="#1e1e1e">a different cluster</text>
+</svg>


### PR DESCRIPTION
Draft of the KubeCon Japan 2026 DR talk write-up.

- New post at `/blog/a-backup-is-not-disaster-recovery`
- 8 SVG diagrams under `public/img/blog/a-backup-is-not-disaster-recovery/`
- All terminal output blocks are real captures from the demo lab (repo: saiyam1814/kubecon-japan-dr-demo)
- Passed the no-slop preflight (claims audit, link check, slop sweep)

Preview via the Cloudflare Pages deployment on this PR, path `/blog/a-backup-is-not-disaster-recovery`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)